### PR TITLE
Fix print summary route param

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -94,7 +94,7 @@ const Index = () => {
               <ProfileManagement />
             </ProtectedRoute>
           } />
-          <Route path="/print-summary/:id" element={
+          <Route path="/print-summary/:recordId" element={
             <ProtectedRoute>
               <PrintSummary />
             </ProtectedRoute>


### PR DESCRIPTION
## Summary
- update Index.tsx to use `recordId` route param for print summary page

## Testing
- `npm run lint` *(fails: Unexpected any and other linter errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fe4c0bb80832283693cc75f62b509